### PR TITLE
iPhoneでコンテンツが画面幅から切れてしまう問題を解消

### DIFF
--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -152,5 +152,5 @@ const options: HTMLReactParserOptions = {
 };
 
 export const ArticleBody: FC<Props> = ({ content }) => {
-  return <Box>{parse(content, options)}</Box>;
+  return <Box {...{ maxWidth: '100%' }}>{parse(content, options)}</Box>;
 };


### PR DESCRIPTION
# 概要
iPhoneでコンテンツが画面幅から切れてしまう問題を解消しました :heart: 

# 問題の調査
iPhoneでコンテンツが画面幅から切れてしまう
<img width="300px" src="https://user-images.githubusercontent.com/62321668/172328864-37d7e8f3-9a74-43fe-a65b-62443719e029.png" alt="画面からコンテンツが見切れている画像" />
このような現象が起こっていた

## 問題の再現する環境
- PC版
  - Chrome（デベロッパーツールによるスマホ相当の画面幅）: ❌ 再現せず
  - Safari : 未検証
- スマートフォン (デバイス：iPhone8)
  - Safari : :heavy_check_mark:  再現
  - Chrome : :heavy_check_mark: 再現

## 原因の考察
再現環境から見ても、iPhone用ブラウザのレンダリングエンジンであるWebkit が悪さをしている可能性が非常に高いと思います。
※ iPhone版のChromeはsafariと同じレンダリングエンジンを使用している 参考：https://news.mynavi.jp/article/20190331-iphone_why/

しかし詳しい原因は分かりませんでした :upside_down_face: 

## 実際に動作がおかしかった部分
https://github.com/Dz0526/blog/blob/main/_posts/setup-linux-bluetooth.md?plain=1#L48
```
info 内でそれぞれ `LongTermKey.Key`と`Rand`、`EDiv`、`IdentityResolvingKey.Key` に対応させて記述する
```
実際に問題になっていたのはこの部分です。長いインラインコードとpが連続する箇所において、何らかの原因で正常に折返しが行われず、親要素を押し広げていたみたいです。
（もちろんiPhoneブラウザ以外の環境では正常に折り返しが行われている）

# 解決策
以上を踏まえて、押し広げられていた親要素の幅を制限するというアプローチで問題を解消しました。
具体的には、ArticleBody の最大幅（`maxWidth:100%`）を設定しています。
